### PR TITLE
Change case of English lib (english -> English)

### DIFF
--- a/lib/dependencies/apk.rb
+++ b/lib/dependencies/apk.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'english'
+require 'English'
 
 require 'dependency'
 


### PR DESCRIPTION
Changes case of `require 'english'` to `require 'English'` in apk.rb. `ops` may sometimes error on Linux because `apk`'s use of [English](https://docs.ruby-lang.org/en/2.1.0/English.html) is case-sensitive, whereas on macOS it might not be. 

```
 /ruby/2.6.0/bundler/gems/ops-52af69c6840f/lib/dependencies/apk.rb:3:in `require': cannot load such file -- english (LoadError)
```

This matches the case in dependency.rb: https://github.com/nickthecook/ops/blob/52af69c6840f084b72901bb1fc9b39e0bb908613/lib/dependency.rb#L4

Further reading: ["LoadError: cannot load such file — english" on Stack Overflow](https://stackoverflow.com/questions/27294172/loaderror-cannot-load-such-file-english)