### PR TITLE
Add Shell Completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,21 @@ $ ops version
 $
 ```
 
+### Shell Auto Completion
+
+To enable ops' shell autocompletion, the `ops completion` command can be provided a shell flavor and it will output an add-on to that shell's configuration file:
+
+#### Bash Example
+```shell
+$ ops completion bash >> ~/.bashrc
+$ source ~/.bashrc
+```
+#### Zsh Example
+```shell
+$ ops completion zsh >> ~/.zshrc
+$ source ~/.zshrc
+```
+
 ### Running
 
 ```shell

--- a/lib/builtins/completion.rb
+++ b/lib/builtins/completion.rb
@@ -1,0 +1,120 @@
+# frozen_string_literal: true
+
+require 'builtin'
+require 'forwards'
+require 'builtins/helpers/enumerator'
+require 'options'
+
+require 'require_all'
+require_rel '.'
+
+module Builtins
+	class Completion < Builtin
+		BASH = "bash"
+		ZSH = "zsh"
+		USAGE = "Usage: ops completion 'bash / zsh'"
+
+		class << self
+			def description
+				"displays completion configuration for the flavor of shell provided"
+			end
+		end
+
+		def run
+			if args.none? || ![BASH, ZSH].include?(args[0])
+				Output.error(USAGE)
+				false
+			elsif args[0] == BASH
+				Output.print(bash_completion)
+				true
+			elsif args[0] == ZSH
+				Output.print(zsh_completion)
+				true
+			end
+		end
+
+		def completion
+			return false if ENV["OPS_AUTO_COMPLETE"].nil? || ENV["COMP_WORDS"].nil? || ENV["COMP_CWORD"].nil?
+
+			word_list = ENV["COMP_WORDS"].split(" ")
+			current_index = ENV["COMP_CWORD"].to_i
+			current_word = word_list[current_index]
+
+			Output.out(completion_list(current_word))
+			true
+		end
+
+		private
+
+		def bash_completion
+			"\n\n_ops_completion()\n"\
+			"{\n"\
+			"    COMPREPLY=( $( COMP_WORDS=\"${COMP_WORDS[*]}\" \\\n"\
+			"                   COMP_CWORD=$COMP_CWORD \\\n"\
+			"                   OPS_AUTO_COMPLETE=1 $1 2>/dev/null ) )\n"\
+			"}\n"\
+			"complete -o default -F _ops_completion ops\n"
+		end
+
+		def zsh_completion
+			"\n\nfunction _ops_completion {\n"\
+			"  local words cword\n"\
+			"  read -Ac words\n"\
+			"  read -cn cword\n"\
+			"  reply=( $( COMP_WORDS=\"$words[*]\" \\\n"\
+			"             COMP_CWORD=$(( cword-1 )) \\\n"\
+			"             OPS_AUTO_COMPLETE=1 $words[1] 2>/dev/null ))\n"\
+			"}\n"\
+			"compctl -K _ops_completion ops\n"
+		end
+
+		def completion_list(filter)
+			(actions | builtins | forwards).select { |item| item =~ /^#{filter}/ }.sort.join(" ")
+		end
+
+		def forwards
+			@forwards ||= Forwards.new(@config).forwards.map do |name, _dir|
+				name
+			end.uniq
+		end
+
+		def builtins
+			@builtins ||= builtin_enumerator.names_by_constant.map do |_klass, names|
+				names.map(&:downcase).map(&:to_s)
+			end.flatten.uniq
+		end
+
+		def actions
+			return [] unless @config["actions"]
+
+			@actions ||= @config["actions"].map do |name, action_config|
+				next unless verify_by_restrictions(action_config)
+
+				include_aliases? ? [name, alias_string_for(action_config)] : name
+			end.flatten.uniq
+		end
+
+		def alias_string_for(action_config)
+			return action_config["alias"].to_s if action_config["alias"]
+
+			""
+		end
+
+		def include_aliases?
+			@include_aliases ||= Options.get("completion.include_aliases")
+		end
+
+		def verify_by_restrictions(action_config)
+			env = ENV["environment"] || "dev"
+			return false if action_config["skip_in_envs"]&.include?(env)
+			return false if action_config["not_in_envs"]&.include?(env)
+			return false if action_config["in_envs"] && !action_config["in_envs"].include?(env)
+
+			true
+		end
+
+		def builtin_enumerator
+			@builtin_enumerator ||= ::Builtins::Helpers::Enumerator
+		end
+	end
+end

--- a/lib/ops.rb
+++ b/lib/ops.rb
@@ -39,6 +39,8 @@ class Ops
 	# rubocop:disable Metrics/MethodLength
 	# better to have all the rescues in one place
 	def run
+		return completion_list if ENV["OPS_AUTO_COMPLETE"]
+
 		# "return" is here to allow specs to stub "exit" without executing everything after it
 		return exit(INVALID_SYNTAX_EXIT_CODE) unless syntax_valid?
 		return exit(MIN_VERSION_NOT_MET_EXIT_CODE) unless min_version_met?
@@ -64,6 +66,12 @@ class Ops
 	# rubocop:enable Metrics/MethodLength
 
 	private
+
+	def completion_list
+		require 'builtins/completion'
+
+		Builtins::Completion.new(@args, @config).completion
+	end
 
 	def syntax_valid?
 		return true unless @action_name.nil?

--- a/ops_team.gemspec
+++ b/ops_team.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
 	s.name = 'ops_team'
-	s.version = '1.14.1'
+	s.version = '1.15.0-rc2'
 	s.authors = [
 		'nickthecook@gmail.com'
 	]

--- a/spec/builtins/completion_spec.rb
+++ b/spec/builtins/completion_spec.rb
@@ -1,0 +1,169 @@
+# frozen_string_literal: true
+
+require 'builtins/completion'
+
+RSpec.describe Builtins::Completion do
+	subject { described_class.new(args, config) }
+	let(:args) { [] }
+	let(:config) do
+		{
+			"actions" => {
+				"action1" => {
+					"command" => "do something",
+					"description" => description,
+					"in_envs" => ["dev"]
+				},
+				"action2" => {
+					"command" => "do something else",
+					"description" => description,
+					"not_in_envs" => ["dev"],
+					"alias" => "ac2"
+				},
+				"third_action" => {
+					"command" => "do a third thing",
+					"description" => description,
+					"skip_in_envs" => ["dev2"]
+				},
+				"other_action" => {
+					"command" => "do other things",
+					"description" => description
+				}
+			},
+			"forwards" => {
+				"backing-test" => "test forward"
+			}
+		}
+	end
+	let(:description) { "does something" }
+	let(:environment) { "dev" }
+	let(:ops_auto_complete) { "1" }
+	let(:comp_words) { "ops " }
+	let(:comp_cword) { "1" }
+
+	describe '#run' do
+		let(:result) { subject.run }
+
+		before do
+			allow(Output).to receive(:error)
+			allow(Output).to receive(:print)
+		end
+
+		context "when no args are supplied" do
+			it "prints usage" do
+				expect(Output).to receive(:error).with("Usage: ops completion 'bash / zsh'")
+				result
+			end
+		end
+
+		context "when bash is requested" do
+			let(:args) { ["bash"] }
+
+			let(:bash_result) do
+				"\n\n_ops_completion()\n"\
+				"{\n"\
+				"    COMPREPLY=( $( COMP_WORDS=\"${COMP_WORDS[*]}\" \\\n"\
+				"                   COMP_CWORD=$COMP_CWORD \\\n"\
+				"                   OPS_AUTO_COMPLETE=1 $1 2>/dev/null ) )\n"\
+				"}\n"\
+				"complete -o default -F _ops_completion ops\n"
+			end
+
+			it "prints bash formatting" do
+				expect(Output).to receive(:print).with(bash_result)
+				result
+			end
+		end
+
+		context "when zsh is requested" do
+			let(:args) { ["zsh"] }
+
+			let(:zsh_result) do
+				"\n\nfunction _ops_completion {\n"\
+				"  local words cword\n"\
+				"  read -Ac words\n"\
+				"  read -cn cword\n"\
+				"  reply=( $( COMP_WORDS=\"$words[*]\" \\\n"\
+				"             COMP_CWORD=$(( cword-1 )) \\\n"\
+				"             OPS_AUTO_COMPLETE=1 $words[1] 2>/dev/null ))\n"\
+				"}\n"\
+				"compctl -K _ops_completion ops\n"
+			end
+
+			it "prints zsh formatting" do
+				expect(Output).to receive(:print).with(zsh_result)
+				result
+			end
+		end
+	end
+
+	describe '#completion' do
+		let(:result) { subject.completion }
+
+		before do
+			allow(Output).to receive(:out)
+			allow(ENV).to receive(:[]).with("environment").and_return(environment)
+			allow(ENV).to receive(:[]).with("OPS_AUTO_COMPLETE").and_return(ops_auto_complete)
+			allow(ENV).to receive(:[]).with("COMP_WORDS").and_return(comp_words)
+			allow(ENV).to receive(:[]).with("COMP_CWORD").and_return(comp_cword)
+		end
+
+		context "when environment variables are not set" do
+			let(:comp_words) { nil }
+			let(:comp_cword) { nil }
+
+			it "returns false" do
+				expect(result).to be false
+			end
+
+			it "doesn't output anything" do
+				expect(Output).not_to receive(:out)
+				result
+			end
+		end
+
+		context "when the search terms are empty" do
+			it "returns true" do
+				expect(result).to be true
+			end
+
+			it "outputs all expected actions" do
+				expect(Output).to receive(:out).with(a_string_matching(/.*action1.*backing-test.*other_action.*third_action.*/))
+				result
+			end
+
+			it "doesn't include not_in_envs filtered action" do
+				expect(Output).not_to receive(:out).with(a_string_matching(/.*action2.*/))
+				result
+			end
+		end
+
+		context "when searching with a partial search term" do
+			let(:comp_words) { "ops ac" }
+			let(:comp_cword) { "1" }
+			let(:environment) { "dev2" }
+
+			before do
+				allow(Options).to receive(:get).with("completion.include_aliases").and_return(true)
+			end
+
+			it "returns true" do
+				expect(result).to be true
+			end
+
+			it "outputs all expected actions" do
+				expect(Output).to receive(:out).with(a_string_matching(/.*ac2.*action2.*/))
+				result
+			end
+
+			it "doesn't include in_envs filtered action" do
+				expect(Output).not_to receive(:out).with(a_string_matching(/.*action1.*/))
+				result
+			end
+
+			it "doesn't include skip_in_envs filtered action" do
+				expect(Output).not_to receive(:out).with(a_string_matching(/.*third_action.*/))
+				result
+			end
+		end
+	end
+end


### PR DESCRIPTION
- Adds `ops completion` command used to output shell configuration blocks
- Each shell config block (zsh / bash) calls `ops` to select appropriate suggestions 

Created for the Jan 2022 Hackathon